### PR TITLE
Add internal cache to improve performance

### DIFF
--- a/tests/phpunit/Unit/BlobStoreTest.php
+++ b/tests/phpunit/Unit/BlobStoreTest.php
@@ -135,7 +135,8 @@ class BlobStoreTest extends \PHPUnit_Framework_TestCase {
 	public function testGetStats() {
 
 		$this->cache->expects( $this->once() )
-			->method( 'getStats' );
+			->method( 'getStats' )
+			->will( $this->returnValue( array() ) );
 
 		$instance = new BlobStore( 'Foo', $this->cache );
 		$instance->getStats();


### PR DESCRIPTION
A production like environment showed that request on long lists suffer from repeated unserialization for a container that is not really necessary therefore employing an internal Lru cache to circumvent those situations.

![image](https://cloud.githubusercontent.com/assets/1245473/7961534/6bfea06a-0a08-11e5-82a1-ee1046b40b58.png)
